### PR TITLE
fix: update nancy workflow with authenticated scan and version bumps

### DIFF
--- a/.github/workflows/nancy.yml
+++ b/.github/workflows/nancy.yml
@@ -11,27 +11,36 @@ on:
 
 jobs:
   build:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     strategy:
         matrix:
-          go-version: [1.24.x]
+          go-version: [1.25.x]
           os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Go 1.x in order to write go.list file
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
     
-    - name: Go mod tidy
-      run: go mod tidy
+    - name: Install Nancy
+      run: |
+        curl -sSL -o nancy https://github.com/sonatype-nexus-community/nancy/releases/download/v1.2.0/nancy-v1.2.0-linux-amd64
+        chmod +x nancy
+        sudo mv nancy /usr/local/bin/
+        file /usr/local/bin/nancy
 
-    - name: WriteGoList
-      run:  go list -json -deps ./... > go.list
-
-    - name: Nancy
-      uses: sonatype-nexus-community/nancy-github-action@main
-      with:
-        nancyCommand: sleuth --loud
+    - name: Nancy Security Scan
+      shell: bash
+      env:
+        OSSINDEX_USERNAME: ${{ secrets.OSSINDEX_USERNAME }}
+        OSSINDEX_TOKEN: ${{ secrets.OSSINDEX_TOKEN }}
+      run: |
+        if [[ -z "${OSSINDEX_USERNAME:-}" || -z "${OSSINDEX_TOKEN:-}" ]]; then
+          echo "::error::Missing OSS Index credentials"
+        fi
+        
+        go list -json -deps ./... | nancy sleuth --username "${OSSINDEX_USERNAME}" --token "${OSSINDEX_TOKEN}"


### PR DESCRIPTION
## Summary

- Add repo fork guard (`if: github.event.pull_request.head.repo.full_name == github.repository`) to skip CI on external PRs
- Bump Go version from 1.24.x to 1.25.x
- Bump `actions/checkout` to v4 and `actions/setup-go` to v5
- Replace `nancy-github-action` with direct Nancy binary install (v1.2.0)
- Add OSS Index authenticated scanning via `OSSINDEX_USERNAME` / `OSSINDEX_TOKEN` secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)